### PR TITLE
reparing 1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog for the Kebechet - a Thoth bot
+
+## [1.0.0-rc.4] - 2018-Jun-25 - goern
+
+### Added
+
+Starting with this release we have a Zuul-CI pipeline that:
+
+* lints on Pull Requrest and gate/merge
+* uploads to pypi (test) on tag

--- a/kebechet/__init__.py
+++ b/kebechet/__init__.py
@@ -3,5 +3,5 @@
 from .update import update
 
 __name__ = 'kebechet'
-__version__ = '1.0.0-rc.2'
+__version__ = '1.0.0-rc.3'
 __author__ = 'Fridolin Pokorny <fridolin.pokorny@gmail.com>'


### PR DESCRIPTION
## [1.0.0-rc.4] - 2018-Jun-25 - goern

### Added

Starting with this release we have a Zuul-CI pipeline that:

* lints on Pull Requrest and gate/merge
* uploads to pypi (test) on tag