### PR TITLE
Fix computing of changelog

### DIFF
--- a/kebechet/managers/info/info.py
+++ b/kebechet/managers/info/info.py
@@ -41,7 +41,7 @@ class InfoManager(ManagerBase):
             return
 
         _LOGGER.info(f"Found issue {_INFO_ISSUE_NAME}, generating report")
-        with cloned_repo(self.service_url, self.slug) as repo:
+        with cloned_repo(self.service_url, self.slug, depth=1) as repo:
             # We could optimize this as the get_issue() does API calls as well. Keep it this simple now.
             self.sm.close_issue_if_exists(
                 _INFO_ISSUE_NAME,

--- a/kebechet/managers/pipfile_requirements/pipfile_requirements.py
+++ b/kebechet/managers/pipfile_requirements/pipfile_requirements.py
@@ -99,7 +99,7 @@ class PipfileRequirementsManager(ManagerBase):
             # TODO: delete branch if already exists
             return
 
-        with cloned_repo(self.service_url, self.slug) as repo:
+        with cloned_repo(self.service_url, self.slug, depth=1) as repo:
             with open('requirements.txt', 'w') as requirements_file:
                 requirements_file.write('\n'.join(pipfile_content))
                 requirements_file.write('\n')

--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -603,7 +603,7 @@ class UpdateManager(ManagerBase):
         # We will keep venv in the project itself - we have permissions in the cloned repo.
         os.environ['PIPENV_VENV_IN_PROJECT'] = '1'
 
-        with cloned_repo(self.service_url, self.slug) as repo:
+        with cloned_repo(self.service_url, self.slug, depth=1) as repo:
             # Make repo available in the instance.
             self.repo = repo
 

--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -43,7 +43,7 @@ def cwd(path: str):
 
 
 @contextmanager
-def cloned_repo(service_url: str, slug: str):
+def cloned_repo(service_url: str, slug: str, **clone_kwargs):
     """Clone the given Git repository and cd into it."""
     if service_url.startswith('https://'):
         service_url = service_url[len('https://'):]
@@ -56,7 +56,7 @@ def cloned_repo(service_url: str, slug: str):
     repo_url = f'git@{service_url}:{slug}.git'
     with TemporaryDirectory() as repo_path, cwd(repo_path):
         _LOGGER.info(f"Cloning repository {repo_url} to {repo_path}")
-        repo = git.Repo.clone_from(repo_url, repo_path, branch='master', depth=1)
+        repo = git.Repo.clone_from(repo_url, repo_path, branch='master', **clone_kwargs)
         repo.config_writer().set_value(
             'user', 'name', os.getenv('KEBECHET_GIT_NAME', 'Kebechet')
         ).release()


### PR DESCRIPTION
There was involved an optimization where only the latest commit was cloned. We
need the whole git history for computing changelog entries.

Fixes: #141 