### PR TITLE
Lower log level when something goes wrong when running Pipenv

### DIFF
--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -95,7 +95,7 @@ pipenv version: {pipenv_version}
         _LOGGER.debug(f"Running pipenv command {cmd!r}")
         result = delegator.run(cmd)
         if result.return_code != 0:
-            _LOGGER.error(result.err)
+            _LOGGER.warning(result.err)
             raise PipenvError(result)
 
         return result.out


### PR DESCRIPTION
Let's reduce error messages reported to Sentry. The callee of this function is
responsible to log if the error is fatal/relevant.

Fixes: #180