### PR TITLE
Version manager searches for __about__.py as well

### DIFF
--- a/kebechet/managers/version/README.rst
+++ b/kebechet/managers/version/README.rst
@@ -5,7 +5,7 @@ Edit version information in sources and open a pull request with tagged commit.
 
 This manager can simplify package releases for you. If you open an issue that requests new version release, this manager will do actions needed on source code level.
 
-A requirement to make this manager operational is that your version should be stated as a string in your `setup.py`, `version.py`  or `__init__.py` file in a variable named `__version__`.
+A requirement to make this manager operational is that your version should be stated as a string in your `setup.py`, `version.py`, `__about__.py`  or `__init__.py` file in a variable named `__version__`.
 
 
 Available Package release commands

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -96,7 +96,7 @@ class VersionManager(ManagerBase):
         adjusted = []
         for root, _, files in os.walk('./'):
             for file_name in files:
-                if file_name in ('setup.py', '__init__.py', 'version.py'):
+                if file_name in ('setup.py', '__init__.py', '__about__.py', 'version.py'):
                     file_path = os.path.join(root, file_name)
                     adjusted_version = self._adjust_version_file(file_path, issue)
                     if adjusted_version:


### PR DESCRIPTION
The `__about__.py` file is used by projects like `cryptography` or
`jupyter-datatables` to specify project metadata, let Kebechet search
for this file to allow them to use version manager as well.

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   kebechet/managers/version/README.rst
modified:   kebechet/managers/version/version.py