### PR TITLE
Be consistent with issue title case

### DIFF
--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -149,7 +149,9 @@ class VersionManager(ManagerBase):
     @staticmethod
     def _get_new_version(issue_title: str, current_version: str) -> typing.Optional[str]:
         """Get next version based on user request."""
-        handler = _RELEASE_TITLES.get(issue_title.lower())
+        issue_title = issue_title.lower()
+
+        handler = _RELEASE_TITLES.get(issue_title)
         if handler:
             try:
                 return handler(current_version)


### PR DESCRIPTION
This fixes the problem where "0.1.0 Release" does not produce a new version, whereas "0.1.0 release" does

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   kebechet/managers/version/version.py