### PR TITLE
Fix permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8
 # Env variable USER specific the kebechet as committer while git branch and git commit creation. 
 # Adjust cache location due to permissions when run in the cluster.
 ENV USER=kebechet \
-    PIPENV_CACHE_DIR=/tmp/.cache \
+    PIPENV_CACHE_DIR=/tmp/kebechet-cache \
     HOME=/home/user/ \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8 \
@@ -18,7 +18,7 @@ RUN \
     dnf install -y --setopt=tsflags=nodocs git python3-pip gcc redhat-rpm-config python3-devel which gcc-c++ &&\
 #    pip3 install git+https://github.com/thoth-station/kebechet &&\
     pip3 install pipenv &&\
-    mkdir -p /home/user/.ssh &&\
+    mkdir -p /home/user/.ssh ${PIPENV_CACHE_DIR} &&\
     chmod a+wrx -R /etc/passwd /home/user
 
 # For local installation from sources.
@@ -26,11 +26,9 @@ RUN \
 # RUN  pip3 install virtualenv && mkdir -p /usr/local/lib/python3.6/site-packages/ && cd /tmp/kebechet/ && python3 setup.py install
 
 COPY . /home/user
-RUN pipenv install
+RUN pipenv install && chmod a+wrx -R ${PIPENV_CACHE_DIR}
 
 # Arbitrary User
 USER 1042 
-
-RUN mkdir /tmp/.cache
 
 CMD ["./app.sh"]


### PR DESCRIPTION
As the pipenv install command creates directory, we need to explictly set its
permissions after that, otherwise permissions will be set to user 1042 which
does not match OpenShift's arbitrary user present in the container image run in
the cluster.