### PR TITLE
kebechet also support release of AICoE SrcOpsMetrics

### DIFF
--- a/config/thoth.yaml
+++ b/config/thoth.yaml
@@ -648,3 +648,13 @@ repositories:
         configuration:
           labels: [bot]
       - name: info
+      - name: version
+        configuration:
+          maintainers:
+            - goern
+            - xtuchyna
+            - pacospace
+          assignees:
+            - sesheta
+          labels: [bot]
+          changelog_file: true


### PR DESCRIPTION
kebechet also supports the release of AICoE SrcOpsMetrics to PyPI.
Related-to: https://github.com/AICoE/SrcOpsMetrics/issues/7
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>