### PR TITLE
[WIP] Replaced update manager with thoth-advise

### DIFF
--- a/config/thoth.yaml
+++ b/config/thoth.yaml
@@ -503,9 +503,9 @@ repositories:
   - slug: thoth-station/metrics-exporter
     token: "{KEBECHET_TOKEN}"
     managers:
-      - name: update
+      - name: thoth-advise
         configuration:
-          labels: [bot]
+          labels: [bot, kebechet]
       - name: info
       - name: version
         configuration:


### PR DESCRIPTION
Depends on - https://github.com/thoth-station/srcops-testing/pull/229
If the advise manager successfully updates srcops-testing