### PR TITLE
Consider app.py and wsgi.py as a source for version

### DIFF
--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -102,7 +102,7 @@ class VersionManager(ManagerBase):
         adjusted = []
         for root, _, files in os.walk('./'):
             for file_name in files:
-                if file_name in ('setup.py', '__init__.py', '__about__.py', 'version.py'):
+                if file_name in ('setup.py', '__init__.py', '__about__.py', 'version.py', 'app.py', 'wsgi.py'):
                     file_path = os.path.join(root, file_name)
                     adjusted_version = self._adjust_version_file(file_path, issue)
                     if adjusted_version:


### PR DESCRIPTION
With this change Kebechet will be more tightly integrated to OpenShift's s2i
conventions for default Python files naming.