### PR TITLE
Fix reStructuredText issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Notes
 To issue an update to Git repository, Kebechet creates branches in the provided repository.
 
 Deploying Kebechet
-=================
+==================
 
 To deploy kebechet on OpenShift cluster. Use the following Ansible command with required parameters:
 


### PR DESCRIPTION
```
README.rst:42: (WARNING/2) Title underline too short.
```

## Related Issues and Dependencies

Kebechet fails to upload to PyPI:

```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading kebechet-1.0.4-py3-none-any.whl
100%|██████████| 51.8k/51.8k [00:00<00:00, 112kB/s] 
NOTE: Try --verbose to see response content.
HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/
````

## This introduces a breaking change

- [x] No

