### PR TITLE
upgrade pip for kebechet container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /home/user
 RUN \
     dnf install -y --setopt=tsflags=nodocs git python38 python3-pip gcc redhat-rpm-config python3-devel which gcc-c++ &&\
 #    pip3 install git+https://github.com/thoth-station/kebechet &&\
+    pip3 install --upgrade pip &&\
     pip3 install pipenv==2018.11.26 &&\
     mkdir -p /home/user/.ssh ${PIPENV_CACHE_DIR} &&\
     chmod a+wrx -R /etc/passwd /home/user


### PR DESCRIPTION
## Related Issues and Dependencies

Related-To: https://github.com/thoth-station/storages/issues/2097

## This introduces a breaking change

- [x] No

## This Pull Request implements

With new packages installed in thoth-storages, the upgrade pip is required for smooth installation.

## Description

upgrade pip for kebechet container image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>
