### PR TITLE
Update manager non-atomic updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     dnf install -y --setopt=tsflags=nodocs git python38 python3-pip gcc redhat-rpm-config python3-devel which gcc-c++ &&\
 #    pip3 install git+https://github.com/thoth-station/kebechet &&\
     pip3 install --upgrade pip &&\
-    pip3 install pipenv==2018.11.26 &&\
+    pip3 install pipenv==2020.11.15 &&\
     mkdir -p /home/user/.ssh ${PIPENV_CACHE_DIR} &&\
     chmod a+wrx -R /etc/passwd /home/user
 

--- a/kebechet/managers/update/messages.py
+++ b/kebechet/managers/update/messages.py
@@ -209,3 +209,12 @@ ISSUE_UNSUPPORTED_PACKAGE = """Kebechet cannot support maintaining this applicat
   ```
   </details>
   """
+
+UPDATE_MESSAGE_BODY = """Kebechet has updated the depedencies to the latest version :rocket:
+The direct dependencies updated in the pull request are -
+Package Name | Old Version | Updated Version | Is Dev
+--- | --- | --- | ---
+{package_name_rows}
+
+Kebechet Version: {kebechet_version}
+"""


### PR DESCRIPTION
## Related Issues and Dependencies
Update manager now gives singular updates instead of atomic updates. 
Example - https://github.com/saisankargochhayat/kebechet_sample/pull/125

I haven't removed some unused functions in the manager, should I? Incase pipenv 2020 gets fixed we can revert the manager back to its original state (that is version 1.1.0)

Updated pipenv==2020.11.15