### PR TITLE
The release PR should close the issue

### DIFF
--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -334,7 +334,7 @@ class VersionManager(ManagerBase):
         body = cls._adjust_pr_body(issue)
         truncated_changelog = changelog[:_MAX_CHANELOG_SIZE]
         body += (
-            "Related: #"
+            "Closes: #"
             + str(issue.id)
             + "\n\n```"
             + "\n\nChangelog:\n"


### PR DESCRIPTION
## Related Issues and Dependencies
Related - https://github.com/thoth-station/kebechet/issues/603
In Incase sesheta doesn't close it, another run could lead to a release, best to close the issue when the release PR is merged. 

@harshad16 I think 1.1.2 tag is missing. 