### PR TITLE
fix the name of the imagestream to-be looked up

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -11,5 +11,5 @@ build:
 deploy:
   project-org: "thoth-station"
   project-name: "thoth-application"
-  image-name: "kebechet-job"
+  image-name: "kebechet"
   overlay-contextpath: "kebechet/overlays/test/imagestreamtag.yaml"


### PR DESCRIPTION
fix the name of the imagestream to-be looked up
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/pull/704#issuecomment-738920826
