### PR TITLE
write outputs of pipenv lock -r to output file

### DIFF
--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -399,10 +399,7 @@ class UpdateManager(ManagerBase):
         """Perform pipenv lock into requirements.txt or requirements-dev.txt file."""
         result = cls.run_pipenv("pipenv lock -r ")
         with open(output_file, "w") as requirements_file:
-            # Remove markers from requirements file.
-            for line in result.splitlines():
-                parts = line.split(" ; ", maxsplit=1)
-                requirements_file.write(parts[0])
+            requirements_file.write(result)
 
     def _create_update(
         self,


### PR DESCRIPTION
## Related Issues and Dependencies

Closes: #683 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

`foo==2.6.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'\n`
was being turned into
`foo==2.6.1`

There is no reason to cut out this information from the requirements.txt file