### PR TITLE
pass environment name to managers and add documentation for expected …

### DIFF
--- a/kebechet/cli.py
+++ b/kebechet/cli.py
@@ -77,8 +77,13 @@ def cli(ctx=None, verbose=0):
 @click.option("-n", "--namespace", envvar="KEBECHET_PROJECT_NAMESPACE", required=True)
 @click.option("-p", "--project", envvar="KEBECHET_PROJECT_NAME", required=True)
 @click.option("-u", "--service-url", envvar="KEBECHET_SERVICE_URL")
+@click.option("-e", "--runtime-environment", envvar="KEBECHET_RUNTIME_ENVIRONMENT")
 def cli_run(
-    service: str, namespace: str, project: str, service_url: Optional[str] = None
+    service: str,
+    namespace: str,
+    project: str,
+    service_url: Optional[str] = None,
+    runtime_environment=Optional[str],
 ):
     """Run Kebechet using provided YAML configuration file."""
     run(
@@ -86,6 +91,7 @@ def cli_run(
         namespace=namespace,
         project=project,
         service_url=service_url,
+        runtime_environment=runtime_environment,
     )
 
 
@@ -95,9 +101,20 @@ def cli_run(
 @click.option(
     "-i", "--analysis_id", metavar="id", envvar="KEBECHET_ANALYSIS_ID", required=True
 )
-def cli_run_results(origin: str, service: str, analysis_id: str):
+@click.option("-e", "--runtime-environment", envvar="KEBECHET_RUNTIME_ENVIRONMENT")
+def cli_run_results(
+    origin: str,
+    service: str,
+    analysis_id: str,
+    runtime_environment: Optional[str] = None,
+):
     """Run Kebechet after results are received (meant to be triggered automatically)."""
-    run_analysis(analysis_id=analysis_id, origin=origin, service=service)
+    run_analysis(
+        analysis_id=analysis_id,
+        origin=origin,
+        service=service,
+        runtime_environment=runtime_environment,
+    )
 
 
 @cli.command("run-url")
@@ -108,13 +125,24 @@ def cli_run_results(origin: str, service: str, analysis_id: str):
 )
 @click.option("-s", "--service", envvar="KEBECHET_SERVICE_NAME")
 @click.option("-m", "--metadata", envvar="KEBECHET_METADATA")
-def cli_run_url(url: str, service: str, metadata: Optional[str] = None):
+@click.option("-e", "--runtime-environment", envvar="KEBECHET_RUNTIME_ENVIRONMENT")
+def cli_run_url(
+    url: str,
+    service: str,
+    metadata: Optional[str] = None,
+    runtime_environment: Optional[str] = None,
+):
     """Run Kebechet by providing url to a git repository service."""
     if metadata is not None:
         meta = json.loads(metadata)
     else:
         meta = None
-    run_url(url=url, service=service, kebechet_metadata=meta)
+    run_url(
+        url=url,
+        service=service,
+        kebechet_metadata=meta,
+        runtime_environment=runtime_environment,
+    )
 
 
 @cli.command("run-webhook")

--- a/kebechet/kebechet_runners.py
+++ b/kebechet/kebechet_runners.py
@@ -80,6 +80,7 @@ def run_url(
     parsed_payload: Optional[Dict[str, Any]] = None,
     kebechet_metadata: Optional[Dict[str, Any]] = None,
     analysis_id: Optional[str] = None,
+    runtime_environment: Optional[str] = None,
 ):
     """Run Kebechet by specifying URL of repository to run on."""
     slug, namespace, project, service_url = _parse_url_4_args(url)
@@ -92,10 +93,16 @@ def run_url(
         parsed_payload=parsed_payload,
         metadata=kebechet_metadata,
         analysis_id=analysis_id,
+        runtime_environment=runtime_environment,
     )
 
 
-def run_analysis(analysis_id: str, origin: str, service: str) -> None:
+def run_analysis(
+    analysis_id: str,
+    origin: str,
+    service: str,
+    runtime_environment: Optional[str] = None,
+) -> None:
     """Run result managers (meant to be triggered automatically)."""
     slug, namespace, project, service_url = _parse_url_4_args(origin)
 
@@ -106,6 +113,7 @@ def run_analysis(analysis_id: str, origin: str, service: str) -> None:
         project=project,
         enabled_managers=["thoth-provenance", "thoth-advise"],
         analysis_id=analysis_id,
+        runtime_environment=runtime_environment,
     )
 
 
@@ -118,6 +126,7 @@ def run(
     parsed_payload: Optional[Dict[Any, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     analysis_id: Optional[str] = None,
+    runtime_environment: Optional[str] = None,
 ) -> None:
     """Run Kebechet using provided YAML configuration file."""
     token = os.getenv(f"{service_type.upper()}_KEBECHET_TOKEN")
@@ -176,6 +185,7 @@ def run(
                 parsed_payload=parsed_payload,
                 token=token,
                 metadata=metadata,
+                runtime_environment=runtime_environment,
             )
             instance.run(**manager_configuration)
         except Exception as exc:  # noqa F841

--- a/kebechet/managers/README.rst
+++ b/kebechet/managers/README.rst
@@ -1,13 +1,15 @@
 Kebechet Managers
 -----------------
 
-This submodule states all the available managers in Kebechet. See each manager's submodule to get all available options each manager provides for you.
+This submodule states all the available managers in Kebechet. See each manager's submodule to get all available options
+each manager provides for you.
 
 Developing your own manager
 ===========================
 
-If you would like to develop your own manager, just derive from `ManagerBase` class and implement `run()` method.
-This method accepts kwargs that are directly passed from configuration file (see `configuration` section of a configuration file):
+If you would like to develop your own manager, just derive from `ManagerBase` class and implement `run()` method. This
+method accepts kwargs that are directly passed from configuration file (see `configuration` section of a configuration
+file):
 
 .. code-block:: python
 
@@ -34,7 +36,32 @@ If you wish to operate on repository source code, you can request to clone it:
             repo.git.add(my_file)
             repo.git.push()
 
-The last thing you need to do, is to register your manager to `REGISTERED_MANAGERS` constant (you can find it in `kebechet/managers/__init__.py` file) so Kebechet knows about your manager. Manager can be referenced by its name in lowercase (class name without the "manager" suffix).
+The last thing you need to do, is to register your manager to `REGISTERED_MANAGERS` constant (you can find it in
+`kebechet/managers/__init__.py` file) so Kebechet knows about your manager. Manager can be referenced by its name in
+lowercase (class name without the "manager" suffix).
 
-Kebechet works as a part of Thoth Ecosystem, please raise an issue or add the new manager to the `KebechetGithubAppInstallations
-<https://github.com/thoth-station/storages/blob/15ed39ef6c8d7bf58037046f3bab2465c5c4bb22/thoth/storages/graph/models.py#L1434>`_ table.
+Overlays
+========
+
+Thoth allows users to specify overlays consisting of different runtime environments.  These runtime environments are
+specified in a users .thoth.yaml file, files associated with a specific runtime environment are located in
+`<overlays-dir>/<runtime-environment-name>`.  If you create a manager which acts on individual runtime environments,
+then the desired behaviour is as follows.
+
+- if no overlays directory is specified in .thoth.yaml and no runtime_environment is passed, then the manager should act
+  only on the first entry in `environments` in .thoth.yaml and changes should be made to the top level directory
+
+- if an overlays directory is specified in .thoth.yaml and no runtime_environment is passed the manager should act on
+  every runtime environment and make changes to the corresponding subdirectory.
+
+- if no overlays directory is specified in .thoth.yaml and a runtime_environment is specified then the manager should
+  run on the specified runtime environment and overwrite files in the top level regardless of the runtime environment
+  used to generate them.
+
+- if an overlays directory is specified in .thoth.yaml and a runtime_environment is also specified then the manager
+  should run on the specified runtime environment and make the changes to the corresponding subdirectory.
+
+Kebechet works as a part of Thoth Ecosystem, please raise an issue or add the new manager to the
+`KebechetGithubAppInstallations
+<https://github.com/thoth-station/storages/blob/15ed39ef6c8d7bf58037046f3bab2465c5c4bb22/thoth/storages/graph/models.py#L1434>`_
+table.

--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -45,9 +45,10 @@ class ManagerBase:
         slug: str,
         service: BaseGitService,
         service_type: str,
-        parsed_payload: dict = None,
-        token: str = None,
-        metadata: dict = None,
+        parsed_payload: Optional[dict] = None,
+        token: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        runtime_environment: Optional[str] = None,
     ):
         """Initialize manager instance for talking to services."""
         self.service_url: str = service.instance_url
@@ -63,12 +64,10 @@ class ManagerBase:
             self.installation = True  # Authenticate as github app.
 
         self.service = service
-
         self.project = service.get_project(namespace=self.owner, repo=self.repo_name)
-
         self._repo = None
-
         self.metadata = metadata
+        self.runtime_environment = runtime_environment
 
     @property
     def repo(self):


### PR DESCRIPTION
## Related Issues and Dependencies

#715 
This is laying the ground work for solving the above issue. It allows for passing an environment to Kebechet as well as outlining the desired behaviour of managers which handle overlays.

Please take a look at the desired behaviour I defined in the managers/README.rst and feel free to suggest changes.

## This introduces a breaking change

- [ ] Yes
- [x] No
