### PR TITLE
Prepend changes instead of Appending to Changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ venv.bak/
 .mypy_cache/
 .idea
 .vscode/
+
+.private_key

--- a/kebechet/managers/version/README.rst
+++ b/kebechet/managers/version/README.rst
@@ -36,8 +36,6 @@ An example configuration:
 
       repositories:
     - slug: thoth-station/kebechet
-      # State token explicitly or let it expand from env vars:
-      token: '{SECRET_TOKEN_IN_ENV}'
       service_type: github  # or gitlab
       # Optionally for self-hosted services:
       # service_url: <URL>

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -162,6 +162,7 @@ class VersionManager(ManagerBase):
                     body=f"Automated version release cannot be performed.\nRelated: #{issue.id}",
                     labels=labels,
                 )
+            return None
 
         if len(adjusted) > 1:
             error_msg = _MULTIPLE_VERSIONS_FOUND_ISSUE_NAME
@@ -180,6 +181,7 @@ class VersionManager(ManagerBase):
                     body=f"{_issue_body}\nRelated: #{issue.id}",
                     labels=labels,
                 )
+            return None
 
         # Return old and new version identifier.
         return adjusted[0][1], adjusted[0][2]
@@ -299,9 +301,9 @@ class VersionManager(ManagerBase):
             ).splitlines()
 
         if version_file:
-            # TODO: We should prepend changes instead of appending them.
             _LOGGER.info("Adding changelog to the CHANGELOG.md file")
-            with open("CHANGELOG.md", "a") as changelog_file:
+            with open("CHANGELOG.md", "r+") as changelog_file:
+                changelog_file.seek(0, 0)
                 changelog_file.write(
                     f"\n## Release {new_version} ({datetime.now().replace(microsecond=0).isoformat()})\n"
                 )
@@ -465,7 +467,7 @@ class VersionManager(ManagerBase):
 
                 pr = self.project.create_pr(
                     title=message,
-                    body=self._construct_pr_body,
+                    body=self._construct_pr_body(issue, changelog),
                     target_branch=self.project.default_branch,
                     source_branch=branch_name,
                 )

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -303,13 +303,33 @@ class VersionManager(ManagerBase):
         if version_file:
             _LOGGER.info("Adding changelog to the CHANGELOG.md file")
             with open("CHANGELOG.md", "r+") as changelog_file:
-                content = changelog_file.read()
+                lines = changelog_file.readlines()
                 changelog_file.seek(0, 0)
-                changelog_file.write(
-                    f"\n## Release {new_version} ({datetime.now().replace(microsecond=0).isoformat()})\n"
-                )
-                changelog_file.write("\n".join(changelog))
-                changelog_file.write("\n" + content)
+                if (
+                    lines[0][0] == "#" and lines[0][1] == " "
+                ):  # checking if title its a title of type "# Title"
+                    changelog_file.write(lines[0])
+                    changelog_file.write(
+                        f"\n## Release {new_version} ({datetime.now().replace(microsecond=0).isoformat()})\n"
+                    )
+                    changelog_file.write("\n".join(changelog) + "\n")
+                    changelog_file.write("".join(lines[1:]))
+                elif (
+                    lines[1][0] == "="
+                ):  # Checking if its a title of type "Title \n ===="
+                    changelog_file.write(lines[0] + lines[1])
+                    changelog_file.write(
+                        f"\n## Release {new_version} ({datetime.now().replace(microsecond=0).isoformat()})\n"
+                    )
+                    changelog_file.write("\n".join(changelog) + "\n")
+                    changelog_file.write("".join(lines[2:]))
+                else:  # No title
+                    changelog_file.write(
+                        f"\n## Release {new_version} ({datetime.now().replace(microsecond=0).isoformat()})\n"
+                    )
+                    changelog_file.write("\n".join(changelog) + "\n")
+                    changelog_file.write("".join(lines))
+
             repo.git.add("CHANGELOG.md")
 
         _LOGGER.info("Computed changelog has %d entries", len(changelog))

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -306,7 +306,7 @@ class VersionManager(ManagerBase):
                 lines = changelog_file.readlines()
                 changelog_file.seek(0, 0)
                 if (
-                    lines[0][0] == "#" and lines[0][1] == " "
+                    lines[0].startswith("# ")
                 ):  # checking if title its a title of type "# Title"
                     changelog_file.write(lines[0])
                     changelog_file.write(

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -305,8 +305,8 @@ class VersionManager(ManagerBase):
             with open("CHANGELOG.md", "r+") as changelog_file:
                 lines = changelog_file.readlines()
                 changelog_file.seek(0, 0)
-                if (
-                    lines[0].startswith("# ")
+                if lines[0].startswith(
+                    "# "
                 ):  # checking if title its a title of type "# Title"
                     changelog_file.write(lines[0])
                     changelog_file.write(

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -303,12 +303,13 @@ class VersionManager(ManagerBase):
         if version_file:
             _LOGGER.info("Adding changelog to the CHANGELOG.md file")
             with open("CHANGELOG.md", "r+") as changelog_file:
+                content = changelog_file.read()
                 changelog_file.seek(0, 0)
                 changelog_file.write(
                     f"\n## Release {new_version} ({datetime.now().replace(microsecond=0).isoformat()})\n"
                 )
                 changelog_file.write("\n".join(changelog))
-                changelog_file.write("\n")
+                changelog_file.write("\n" + content)
             repo.git.add("CHANGELOG.md")
 
         _LOGGER.info("Computed changelog has %d entries", len(changelog))


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Issue#736 - prepending instead of appending to CHANGELOG.md

## Description

Made Prepending instead of appending, edited README in versioning to match current state, fixed some small bugs that would cause errors in edge cases
