### PR TITLE
fixed bug with unrelated histories where khebhut doesn't create PR

### DIFF
--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -280,7 +280,8 @@ class VersionManager(ManagerBase):
             )
             # Use the initial commit if this the previous tag was not found - this
             # can be in case of the very first release.
-            old_version = repo.git.rev_list("HEAD", max_parents=0)
+            old_versions = repo.git.rev_list("HEAD", max_parents=0).split()
+            old_version = old_versions[-1]
 
         _LOGGER.info("Smart Log : %s", str(changelog_smart))
 


### PR DESCRIPTION
## Related Issues and Dependencies

Closes: #663

## This introduces a breaking change

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements
 
Fixes a bug where merging updates with unrelated histories creates errors with git log.

## Description

git rev-list gives a string of commits from parent commit, but that causes errors since git log doesn't take it in that format, so just took the earliest commit in chronological order to log all the commits up to HEAD.