### PR TITLE
add args to get access token

### DIFF
--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -64,8 +64,9 @@ def cloned_repo(manager: "ManagerBase", branch="master", **clone_kwargs):
         # This is mostly internal error - we require service URL to have protocol explicitly set
         raise NotImplementedError
 
+    namespace, repository = slug.split("/")
     if manager.installation:
-        access_token = manager.service.authentication.get_token()
+        access_token = manager.service.authentication.get_token(namespace, repository)
         repo_url = f"https://{APP_NAME}:{access_token}@{service_url}/{slug}"
     else:
         repo_url = f"git@{service_url}:{slug}.git"


### PR DESCRIPTION
## Related Issues and Dependencies

```
  File "/usr/lib64/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/home/user/kebechet/utils.py", line 68, in cloned_repo
    access_token = manager.service.authentication.get_token()
TypeError: get_token() missing 2 required positional arguments: 'namespace' and 'repo'
```
