### PR TITLE
if requirements.txt does not exist it must be created

### DIFF
--- a/kebechet/managers/pipfile_requirements/pipfile_requirements.py
+++ b/kebechet/managers/pipfile_requirements/pipfile_requirements.py
@@ -25,6 +25,7 @@ from kebechet.managers.manager import ManagerBase
 from kebechet.utils import cloned_repo
 
 import toml
+from github.GithubException import UnknownObjectException
 
 _LOGGER = logging.getLogger(__name__)
 # Github and Gitlab events on which the manager acts upon.
@@ -94,8 +95,13 @@ class PipfileRequirementsManager(ManagerBase):
             else sorted(self.get_pipfile_requirements(file_contents))
         )
 
-        file_contents = self.project.get_file_content("requirements.txt")
-        requirements_txt_content = sorted(file_contents.splitlines())
+        try:
+            file_contents = self.project.get_file_content("requirements.txt")
+            requirements_txt_content = sorted(file_contents.splitlines())
+        except (FileNotFoundError, UnknownObjectException):
+            requirements_txt_content = (
+                []
+            )  # requirements.txt file has not been created so the manager will create it
 
         if pipfile_content == requirements_txt_content:
             _LOGGER.info("Requirements in requirements.txt are up to date")


### PR DESCRIPTION
## Related Issues and Dependencies

aicoe-aiops/ocp-ci-analysis#345

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

If requirements.txt file does not exist when running pipfile_requirements manager then ogr was throwing an exception that the file did not exist. However it is possible that the first time the user installs this manager they won't have a `requirements.txt` file so we shouldn't expect to find one in their repository.
