### PR TITLE
make opening issues configurable and add 'kebechet' section to config

### DIFF
--- a/kebechet/kebechet_runners.py
+++ b/kebechet/kebechet_runners.py
@@ -192,9 +192,15 @@ def run(
             )
             instance.run(**manager_configuration)
         except Exception as exc:  # noqa F841
-            _create_issue_from_exception(
-                manager_name=manager_name, ogr_service=ogr_service, slug=slug, exc=exc
-            )
+            if (keb_config := config.config.get("kebechet")) and keb_config.get(
+                "issue_on_exception"
+            ):
+                _create_issue_from_exception(
+                    manager_name=manager_name,
+                    ogr_service=ogr_service,
+                    slug=slug,
+                    exc=exc,
+                )
             _LOGGER.exception(
                 "An error occurred during run of manager %r %r for %r, skipping",
                 manager,


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/jupyterlab-requirements/issues/416

Kebechet is opening a lot of issues on some repositories. This can be seen as spam from users. Here we can make it configurable so that it can be easily shut off. (off by default)

This also adds

```yaml
kebechet:
   ...
```
block to .thoth.yaml configuration as this config does not fit in manager specific config.

## This introduces a breaking change

- [ ] Yes
- [x] No
