### PR TITLE
do not raise issue for conn error

### DIFF
--- a/kebechet/kebechet_runners.py
+++ b/kebechet/kebechet_runners.py
@@ -201,12 +201,13 @@ def run(
             )
             instance.run(**manager_configuration)
         except Exception as exc:  # noqa F841
-            _create_issue_from_exception(
-                manager_name=manager_name,
-                ogr_service=ogr_service,
-                slug=slug,
-                exc=exc,
-            )
+            if not isinstance(exc, ConnectionError):
+                _create_issue_from_exception(
+                    manager_name=manager_name,
+                    ogr_service=ogr_service,
+                    slug=slug,
+                    exc=exc,
+                )
             _LOGGER.exception(
                 "An error occurred during run of manager %r %r for %r, skipping",
                 manager,


### PR DESCRIPTION
## Related Issues and Dependencies

Connection errors usually occur due to services being down. For example right now, user-api is down so when the kebechet advise manager runs it raises a connection error because it is unreachable. Issues should be opened for uncaught exceptions that occur due to bugs within Kebechet not due to bugs from without.

## This introduces a breaking change

- [ ] Yes
- [x] No

