### PR TITLE
Fix markdown format for table rows

### DIFF
--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -703,7 +703,9 @@ class UpdateManager(ManagerBase):
                 details.get("new_version"),
                 details.get("dev"),
             )
-            package_name_rows += f"**{package}**|{old_version}|{new_version}|{is_dev}\n"
+            package_name_rows += (
+                f"|**{package}**|{old_version}|{new_version}|{is_dev}|\n"
+            )
         body = UPDATE_MESSAGE_BODY.format(
             package_name_rows=package_name_rows, kebechet_version=kebechet_version
         )


### PR DESCRIPTION

## Related Issues and Dependencies

#822

## This introduces a breaking change

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Fix the markdown formatting of the package rows in the table within update PRs.

## Description

The fix in #823 fixes the formatting of the header of the table in the reported issues by adding the missing leading `|`.

This PR adds that pipe char to the rows that go after the header, i.e. the rest of the table, formed by the list of packages to update.

