### PR TITLE
do not initialize repo with any managers

### DIFF
--- a/kebechet/managers/config_initializer/resources/simple.thoth.yaml
+++ b/kebechet/managers/config_initializer/resources/simple.thoth.yaml
@@ -10,7 +10,4 @@ runtime_environments:
     python_version: "3.8"
     recommendation_type: latest
 
-managers:
-  - name: thoth-advise
-    configuration:
-      labels: [bot]
+managers: []


### PR DESCRIPTION
## Related Issues and Dependencies

Some repositories can't receive advises because they have no Python so we shouldn't install the advise manager by default
