### PR TITLE
patch read write method for changelog update

### DIFF
--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -304,7 +304,8 @@ class VersionManager(ManagerBase):
 
         if version_file:
             _LOGGER.info("Adding changelog to the CHANGELOG.md file")
-            with open("CHANGELOG.md", "w+") as changelog_file:
+            file_mode = "r+" if os.path.exists("CHANGELOG.md") else "w+"
+            with open("CHANGELOG.md", file_mode) as changelog_file:
                 lines = changelog_file.readlines()
                 changelog_file.seek(0, 0)
                 if lines[0].startswith(


### PR DESCRIPTION
patch read write method for changelog update
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #866 

## Description

`w+` only read from file , after something it write by **it** .

This change would truncate the changelog.md as using w+
`with open("CHANGELOG.md", "w+") as changelog_file:`
