### PR TITLE
Add Goern, Harshad and Pep as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - codificat
   - fridex
-  - pacospace
-  - kpostoffice
-  - sesheta
-  - sefkhet-abwy
-reviewers:
-  - kpostoffice
+  - goern
   - harshad16
+  - kpostoffice
+  - pacospace
+  - sefkhet-abwy
+  - sesheta
+reviewers:
+  - harshad16
+  - kpostoffice
 
 labels:
   - sig/cyborgs


### PR DESCRIPTION
## This Pull Request implements

Add three approvers for this repo:

- codificat (myself)
- goern
- harshad16

Also sorted the list alphabetically.

Harshad was in the reviewers list but not an approver.

Adding Harshad and Goern means they can /approve without [ab]using repo ownership powers :innocent: 