### PR TITLE
Remove the maintainers section from .thoth.yaml

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -18,10 +18,6 @@ managers:
   - name: info
   - name: version
     configuration:
-      maintainers:
-        - sesheta
-        - goern
-        - fridex
       assignees:
         - sesheta
       labels: [bot]


### PR DESCRIPTION

## Related Issues and Dependencies

https://github.com/thoth-station/kebechet/issues/902#issuecomment-968810188
#876 

## This Pull Request implements

Remove the `maintainers` section from `.thoth.yaml` so the list of approvers from the OWNERS file is used instead.

## Description

The default is to use the list of approvers in the OWNERS file, see e.g. #876 

This removes redundancy and/or conflicting/confusing information.
<!--- Describe your changes in detail -->
