### PR TITLE
if we have already cloned to dir, return repo from dir

### DIFF
--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -91,9 +91,12 @@ def cloned_repo(manager: "ManagerBase", branch=None, **clone_kwargs):
 
     if _CLONE_DIRECTORY is not None:
         with cwd(_CLONE_DIRECTORY):
-            repo = _clone_repo_and_set_vals(
-                repo_url, _CLONE_DIRECTORY, branch, **clone_kwargs
-            )
+            try:
+                repo = _clone_repo_and_set_vals(
+                    repo_url, _CLONE_DIRECTORY, branch, **clone_kwargs
+                )
+            except git.GitCommandError:
+                repo = git.Repo(_CLONE_DIRECTORY)
             yield repo
     else:
         with TemporaryDirectory() as repo_path, cwd(repo_path):


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/support/issues/141

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

If the repo has already been cloned we do not need to clone it again. This assumes that any run of Kebechet will only use this function to clone the repository that it is acting on. If this is not true then we can add a line like `os.path.join(clone_dir, project_name)`

