### PR TITLE
check if .git exists so that we don't catch all gitcommand exceptions

### DIFF
--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -91,12 +91,12 @@ def cloned_repo(manager: "ManagerBase", branch=None, **clone_kwargs):
 
     if _CLONE_DIRECTORY is not None:
         with cwd(_CLONE_DIRECTORY):
-            try:
+            if os.path.isdir(os.path.join(_CLONE_DIRECTORY, ".git")):
+                repo = git.Repo(_CLONE_DIRECTORY)
+            else:
                 repo = _clone_repo_and_set_vals(
                     repo_url, _CLONE_DIRECTORY, branch, **clone_kwargs
                 )
-            except git.GitCommandError:
-                repo = git.Repo(_CLONE_DIRECTORY)
             yield repo
     else:
         with TemporaryDirectory() as repo_path, cwd(repo_path):


### PR DESCRIPTION
## Related Issues and Dependencies

#908 
