### PR TITLE
Already cloned dirs needs to fetch new info for proper management

### DIFF
--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -93,9 +93,11 @@ def cloned_repo(manager: "ManagerBase", branch=None, **clone_kwargs):
         with cwd(_CLONE_DIRECTORY):
             if os.path.isdir(os.path.join(".", ".git")):
                 repo = git.Repo(".")
+                repo.remote().fetch()
                 repo.git.checkout(branch)
             else:
                 repo = _clone_repo_and_set_vals(repo_url, ".", branch, **clone_kwargs)
+                repo.remote().fetch()
             yield repo
             repo.git.clean("-xdf")
     else:


### PR DESCRIPTION
Already cloned dirs needs to fetch new info for proper management
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #917 

## Description

Assuming that pre-existing clone repo doesn't have new tags or commit information.
So fetch would keep it up to date.

Example:
```
>>> from git import Repo 
>>> repo = Repo(".")
>>> tags = repo.git.tag().splitlines()
>>> tags
[]
>>> repo.remote().fetch()
[<git.remote.FetchInfo object at 0x7fd637ca9cc0>, <git.remote.FetchInfo object at 0x7fd637cb4400>, <git.remote.FetchInfo object at 0x7fd637cb4680>, <git.remote.FetchInfo object at 0x7fd637cb4130>, <git.remote.FetchInfo object at 0x7fd637cb4630>, <git.remote.FetchInfo object at 0x7fd637cb4180>, <git.remote.FetchInfo object at 0x7fd637cb4220>, <git.remote.FetchInfo object at 0x7fd637cb4310>, <git.remote.FetchInfo object at 0x7fd637cb44a0>, <git.remote.FetchInfo object at 0x7fd637cb45e0>, <git.remote.FetchInfo object at 0x7fd637cb4270>, <git.remote.FetchInfo object at 0x7fd637cb42c0>, <git.remote.FetchInfo object at 0x7fd637cb48b0>, <git.remote.FetchInfo object at 0x7fd637cb4b80>]
>>> tags = repo.git.tag().splitlines()
>>> tags
['0.0.3', '0.0.4', '0.0.5', '0.0.6', '0.0.7', 'v0.1.0']
```