### PR TITLE
Keep the branch versioning the with prefix v

### DIFF
--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -485,7 +485,7 @@ class VersionManager(ManagerBase):
                     issue.close()
                     return
 
-                branch_name = "kebechet-v" + version_identifier
+                branch_name = "v" + version_identifier
                 repo.git.checkout("HEAD", b=branch_name)
                 message = _VERSION_PULL_REQUEST_NAME.format(version_identifier)
                 repo.index.commit(message)


### PR DESCRIPTION
Keep the branch versioning the with prefix v
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

The change of the branch version causes issues with tag release
as the sefkhet-abwy take the name of the branch to create the tag, it would create the tag with the same name.
Let's keep the branch of the version the same.
