### PR TITLE
Fix format string reference to environment name

### DIFF
--- a/kebechet/managers/update/messages.py
+++ b/kebechet/managers/update/messages.py
@@ -144,7 +144,7 @@ Most likely the deployment build will fail.
 For more information, see [Pipfile]({pip_url}) and [Pipfile.lock]({piplock_url}).
 """
 
-ISSUE_NO_DEPENDENCY_MANAGEMENT = """No dependency management found for the {environment_name} environment. If you want
+ISSUE_NO_DEPENDENCY_MANAGEMENT = """No dependency management found for the {env_name} environment. If you want
 to keep your dependencies managed, please submit `Pipfile` or `requirements.in` or `requirements-dev.in` file.
 
 To generate a `Pipfile`, use:


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes https://github.com/thoth-station/support/issues/147

## Description

Following the change in #867 from `environment_name` to `env_name`, a string was pending an update on the reference.

## Additional context

The string is referenced in https://github.com/thoth-station/kebechet/blob/2d65f91577637f5de75d3dcdbf324d0c81951ab0/kebechet/managers/update/update.py#L1039