### PR TITLE
use env variable for kebechets name

### DIFF
--- a/kebechet/managers/thoth_advise/thoth_advise.py
+++ b/kebechet/managers/thoth_advise/thoth_advise.py
@@ -21,6 +21,7 @@ import logging
 import json
 import typing
 import yaml
+import os
 from thamos import lib
 
 import git  # noqa F401
@@ -83,6 +84,9 @@ _INTERNAL_TRIGGER_ISSUE_BODY_LOOKUP = {
     InternalTriggerEnum.MISSING_PACKAGE.value: MISSING_PACKAGE_ISSUE_BODY,
     InternalTriggerEnum.MISSING_VERSION.value: MISSING_PACKAGE_VERSION_ISSUE_BODY,
 }
+
+
+APP_NAME = os.getenv("GITHUB_APP_NAME", "khebhut")
 
 
 def _runtime_env_name_from_advise_response(response: dict):
@@ -246,13 +250,9 @@ class ThothAdviseManager(ManagerBase):
         try:
             with open("OWNERS", "r") as owners_file:
                 owners = yaml.safe_load(owners_file)
-            return list(map(str, owners.get("approvers") or [])) + [
-                self.service.user.get_username()
-            ]
+            return list(map(str, owners.get("approvers") or [])) + [APP_NAME]
         except FileNotFoundError:
-            return self.project.who_can_merge_pr().append(
-                self.service.user.get_username()
-            )
+            return self.project.who_can_merge_pr().append(APP_NAME)
 
     def _close_advise_issues4users_lacking_perms(self):
         permitted_users = self._get_users_with_permission()


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/support/issues/140

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

instead of getting username info from ogr we can get it from the environment
