### PR TITLE
Unpin fasttext version from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,6 @@ GitPython = ">=3.1.0"
 PyYAML = "*"
 typing-extensions = "*"
 ogr = "*"
-fasttext = "==0.9.1"
 
 [dev-packages]
 pytest = "*"


### PR DESCRIPTION
## Related Issues and Dependencies

The addition of `fasttext` to `Pipfile` was done as an attempt to fix the problem with image building, in #900.
As seen in #962 the problem is still present, and I believe it's unrelated to the `fasttext` version

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Remove the explicit inclusion of a `fasttext` version in the Pipfile, as it should not be necessary.
