### PR TITLE
Enable TLS verification in the sample default configuration

### DIFF
--- a/kebechet/managers/config_initializer/resources/simple.thoth.yaml
+++ b/kebechet/managers/config_initializer/resources/simple.thoth.yaml
@@ -1,5 +1,5 @@
 host: khemenu.thoth-station.ninja
-tls_verify: false
+tls_verify: true
 requirements_format: pipenv
 
 runtime_environments:


### PR DESCRIPTION
Subject basically says it all: it's about setting `tls_verify` to `true` in the configuration initialization that the config initializer suggests.
