### PR TITLE
check before trying to unshallow a repo

### DIFF
--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -97,7 +97,10 @@ def cloned_repo(manager: "ManagerBase", branch: str = None, **clone_kwargs):
                 depth = clone_kwargs.get("depth")
                 if depth:
                     repo.remote().fetch(depth=depth)
-                else:
+                elif (
+                    repo.git.execute(["git", "rev-parse", "--is-shallow-repository"])
+                    == "true"
+                ):
                     repo.git.fetch(unshallow=True)
                 repo.git.checkout(branch)
             else:


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/support/issues/185

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

`git revparse --is-shallow-repository` returns 'true' if the repo is shallow. This can be used to gate the fetch command below which was causing exceptions
