### PR TITLE
use consistent name for 'has_prev_release'

### DIFF
--- a/kebechet/managers/thoth_advise/thoth_advise.py
+++ b/kebechet/managers/thoth_advise/thoth_advise.py
@@ -139,7 +139,7 @@ class ThothAdviseManager(ManagerBase):
             "message_justification"
         ):
             body = _INTERNAL_TRIGGER_PR_BODY_LOOKUP[
-                kebechet_metadata.get("message_justification")
+                kebechet_metadata.get("message_justification")  # type: ignore
             ].format(
                 package=kebechet_metadata.get("package_name"),
                 version=kebechet_metadata.get("package_version"),

--- a/kebechet/managers/version/release_triggers.py
+++ b/kebechet/managers/version/release_triggers.py
@@ -95,7 +95,7 @@ class BaseTrigger:
                         )
         return adjusted
 
-    def construct_pr_body(self, changelog: List[str], tag_missing: bool):
+    def construct_pr_body(self, changelog: List[str], has_prev_release: bool):
         """Construct PR body for trigger."""
         raise NotImplementedError
 
@@ -238,19 +238,19 @@ class ReleasePRlabels(BaseTrigger):
         list_of_labels = [lbl.name for lbl in self.pull_request.labels]
         return self.label_config.index_from_label_list(list_of_labels) is not None
 
-    def construct_pr_body(self, changelog: List[str], tag_missing: bool):
+    def construct_pr_body(self, changelog: List[str], has_prev_release: bool):
         """Construct body of the opened pull request with version update.
 
         Args:
             changelog (List[str]): List of individual changes based off of commits
-            tag_missing (bool): Whether or not the was a previous tag for the repository
+            has_prev_release (bool): Whether or not the was a previous tag for the repository
 
         Returns:
             (str): The PR containing the new version string's body.
         """
         body = ""
         truncated_changelog = changelog[: constants._MAX_CHANELOG_SIZE]
-        if tag_missing:
+        if not has_prev_release:
             body = body + "\n" + RELEASE_TAG_MISSING_WARNING
         body += (
             "\n\nFrom: #"
@@ -421,14 +421,14 @@ class ReleaseIssue(BaseTrigger):
             f"Hey, @{self.issue.author}!\n\nYour possible backwards incompatible changes will be released by this PR.",
         )
 
-    def construct_pr_body(self, changelog: List[str], tag_missing: bool) -> str:
+    def construct_pr_body(self, changelog: List[str], has_prev_release: bool) -> str:
         """Construct body of the opened pull request with version update."""
         # Copy body from the original issue, this is helpful in case of
         # instrumenting CI (e.g. Depends-On in case of Zuul) so automatic
         # merges are perfomed as desired.
         body = self._adjust_pr_body()
         truncated_changelog = changelog[: constants._MAX_CHANELOG_SIZE]
-        if tag_missing:
+        if not has_prev_release:
             body = body + "\n" + RELEASE_TAG_MISSING_WARNING
         body += (
             "\n\nCloses: #"

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -155,7 +155,9 @@ class VersionManager(ManagerBase):
             # If this PR already exists, this will fail.
             pr = self.project.create_pr(
                 title=message,
-                body=trigger.construct_pr_body(changelog, has_prev_release),
+                body=trigger.construct_pr_body(
+                    changelog=changelog, has_prev_release=has_prev_release
+                ),
                 target_branch=self.project.default_branch,
                 source_branch=branch_name,
             )


### PR DESCRIPTION
## Related Issues and Dependencies
Fixes: https://github.com/thoth-station/kebechet/issues/987
## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Keeps the naming consistent for determining whether github repo has previous releases.