### PR TITLE
Add commit hashes to the changelog entries

### DIFF
--- a/kebechet/managers/version/utils.py
+++ b/kebechet/managers/version/utils.py
@@ -150,7 +150,7 @@ def _compute_changelog(
         _LOGGER.info("Classifier : %s", changelog_classifier)
         _LOGGER.info("Format : %s", changelog_format)
         changelog = repo.git.log(
-            f"{old_version}..HEAD", no_merges=True, format="%s"
+            f"{old_version}..HEAD", no_merges=True, format="%h %s"
         ).splitlines()
         changelog = generate_log(
             changelog,
@@ -159,7 +159,7 @@ def _compute_changelog(
         )
     else:
         changelog = repo.git.log(
-            f"{old_version}..HEAD", no_merges=True, format="* %s"
+            f"{old_version}..HEAD", no_merges=True, format="* %h %s"
         ).splitlines()
 
     if version_file:


### PR DESCRIPTION
## Related Issues and Dependencies

Resloves #150 

## This introduces a breaking change

No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This adds short commit hashes to the changelog entries, by modifying the formatting string passed to `git log` from `%s` to `%h %s`

## Description

Example output:

```
>>> from git import Repo
>>> from kebechet.managers.version.utils import _compute_changelog
>>> repo = Repo()
>>> from thoth.glyph import MLModel, Format
>>> changelog = _compute_changelog(repo, 'v1.7.3', 'HEAD', True, MLModel.DEFAULT.name, Format.DEFAULT.name, 'v1.7.3')
>>> for entry in changelog:
...     print(entry)
... 
### Features
* d1003c7 Add commit hashes to the changelog entries
* 8455bf8 :arrow_up: Automatic update of dependencies by Kebechet for the rhel-8 environment
* cd7fbf5 :arrow_up: Automatic update of dependencies by Kebechet for the rhel-8 environment
* 1268243 :medal_sports: set badges for easy access to content
* aec4de6 :arrow_up: Automatic update of dependencies by Kebechet for the rhel-8 environment
* 28b8f92 :arrow_up: Automatic update of dependencies by Kebechet for the rhel-8 environment
* 4f53d80 :arrow_up: Automatic update of dependencies by Kebechet for the rhel-8 environment (#984)
### Improvements
* f7177ee use consistent name for 'has_prev_release'
```
