### PR TITLE
Update the label to use on issue creation

### DIFF
--- a/kebechet/managers/update/messages.py
+++ b/kebechet/managers/update/messages.py
@@ -80,7 +80,7 @@ For more information, see [Pipfile]({pip_url}) and [Pipfile.lock]({piplock_url})
 
 Once this issue is resolved, the issue will be automatically closed by bot.
 
-/label thoth/potential-flake
+/label thoth/potential-observation
 /kind bug
 /priority critical-urgent
 """


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/thoth-application/issues/2245

## This introduces a breaking change

No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

The `thoth/potential-flake` label was renamed to `thoth/potential-observation` across thoth github repos (https://github.com/thoth-station/core/commit/9c5d0fb414279d889923d731f956926bf26748ae).

This PR updates the template message for issue creation that references this label to use the updated version.

