### PR TITLE
handle case where no packages section exists in Pipfile

### DIFF
--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -190,7 +190,8 @@ class UpdateManager(ManagerBase):
             ) from exc
 
         default = list(
-            package_name.lower() for package_name in pipfile_content["packages"].keys()
+            package_name.lower()
+            for package_name in pipfile_content.get("packages", {}).keys()
         )
         develop = list(
             package_name.lower()


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/support/issues/162

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Use `.get("package", {})` so that there is a good default if the section doesn't exist. This is already used below for `dev-packages`
