### PR TITLE
Bugfix: bump black version and fixing git repo typing bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: [--ignore-missing-imports]
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -63,7 +63,7 @@ class ManagerBase:
 
         self.service = service
         self.project = service.get_project(namespace=self.owner, repo=self.repo_name)
-        self._repo = None
+        self._repo: git.Repo = None
         self.metadata = metadata
         self.runtime_environment = runtime_environment
 


### PR DESCRIPTION
## Related Issues and Dependencies

Related to [thoth-station/s2i-generic-data-science-notebook issue 48](https://github.com/thoth-station/s2i-generic-data-science-notebook/issues/48), although this will not address that issue. This bugfix came up in the process of addressing that issue.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This Pull Request implements

The package `_unicodefun` was removed from `click`, and this did not work with Black v 22.0.1. Therefore I bumped the version of Black to the next version for which it would work (v22.3.0).

Additionally typing the `self.__repo` as `git.Repo` with no default value to address tests.