### PR TITLE
fix: open issue in the case of uninitialized overlay dir

### DIFF
--- a/kebechet/managers/update/messages.py
+++ b/kebechet/managers/update/messages.py
@@ -237,3 +237,11 @@ The direct dependencies updated in the pull request are -
 This Pull Request is based on a [Project Thoth GitHub App](https://github.com/marketplace/khebhut),
 and [Kebechet](https://github.com/thoth-station/kebechet) v{kebechet_version}
 """
+
+UNINIT_OVERLAY_DIR_BODY = """Kebechet was unable to run update manager for the {env} runtime environment. The overlay
+directory associated with it has not been initialized. See below for more info:
+
+```
+{exception}
+```
+"""


### PR DESCRIPTION
## Related Issues and Dependencies

closes: https://github.com/thoth-station/support/issues/215

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Open issue when overlay directory for runtime env hasn't been initialized
