### PR TITLE
fix: adjust pipenv cmd limit downward (leave space for dep graph)

### DIFF
--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -92,7 +92,7 @@ _EVENTS_SUPPORTED = ["push", "issues", "issue", "merge_request"]
 # updated on subsequent calls.
 
 _INVALID_BRANCH_CHARACTERS = [":", "?", "[", "\\", "^", "~", " ", "\t"]
-MAX_PIPENV_CMD_LEN = 60000  # max gh issue/comment is 65,536 this leaves ~5000 characters for the rest of the issue
+MAX_PIPENV_CMD_LEN = 50000  # max gh issue/comment is 65,536 this leaves ~5000 characters for the rest of the issue
 
 
 def _string2branch_name(string: str):


### PR DESCRIPTION
## Related Issues and Dependencies

closes: https://github.com/thoth-station/support/issues/206

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Issues still went over so I lowered the limit on cmd error length
