### PR TITLE
Cleanup branch after  PR is merged and tag is created

### DIFF
--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -165,6 +165,11 @@ pipenv version: {pipenv_version}
             fork_username=self.project.namespace if self.project.is_fork else None,
         )
 
+    def pr_comment(self, id: int, body: str):
+        """Comment on the PR."""
+        pr = self.project.get_pr(id)
+        pr.comment(body=body)
+
     def run(self, labels: list) -> typing.Optional[dict]:
         """Run the given manager implementation."""
         raise NotImplementedError

--- a/kebechet/managers/version/version.py
+++ b/kebechet/managers/version/version.py
@@ -226,8 +226,27 @@ class VersionManager(ManagerBase):
                         ["git", "push", "origin", f"refs/tags/{tag_version}"]
                     )
                 )
-            return
+                try:
+                    # Branch name is same as tag version
+                    _LOGGER.info(f"Deleting branch {tag_version}")
+                    repo.git.execute(
+                        [
+                            "git",
+                            "push",
+                            "origin",
+                            "-d",
+                            f"refs/heads/{tag_version}",
+                        ]
+                    )
 
+                except Exception:
+                    _LOGGER.exception(f"Failed to delete branch {tag_version}")
+                    self.pr_comment(
+                        utils._pr_id_from_webhook(self.parsed_payload),
+                        body=f"Failed to delete branch {tag_version} , due to permissions issue",
+                    )
+
+            return
         if (
             pr_releases
             and self.parsed_payload


### PR DESCRIPTION
Fixes cleaning up remote branch after pr is merged and tag is created

## Related Issues and Dependencies
https://github.com/thoth-station/kebechet/issues/1059
…


## This Pull Request implements
As part of the cleanup, it checks if pr has been merged, creates the tag, and deletes the branch on the remote.