### PR TITLE
fetch branch using git.fetch before trying to use it

### DIFF
--- a/kebechet/managers/config_initializer/config_initializer.py
+++ b/kebechet/managers/config_initializer/config_initializer.py
@@ -24,6 +24,7 @@ import importlib.resources as pkg_resources
 from kebechet.managers.manager import ManagerBase
 from kebechet.utils import cloned_repo
 from . import resources
+from ogr.abstract import PRStatus
 
 _INFO_ISSUE_NAME = "Kebechet info"
 
@@ -64,7 +65,7 @@ class ConfigInitializer(ManagerBase):
         thoth_config = pkg_resources.read_text(resources, "simple.thoth.yaml")
 
         with cloned_repo(self, depth=1, branch=self.project.default_branch) as repo:
-            prs = self.get_prs_by_branch(_BRANCH_NAME)
+            prs = self.get_prs_by_branch(_BRANCH_NAME, status=PRStatus.all)
             if len(prs) > 0:
                 _LOGGER.debug("PR initializing .thoth.yaml already exists skipping...")
                 return None

--- a/kebechet/utils.py
+++ b/kebechet/utils.py
@@ -69,6 +69,12 @@ def _clone_repo_and_set_vals(repo_url, repo_path, **clone_kwargs) -> git.Repo:
     return repo
 
 
+def fetch_and_checkout_branch(repo: git.Repo, branch_name: str):
+    """Fetch branch from origin and check it out locally."""
+    repo.git.fetch("origin", branch_name)
+    repo.git.checkout(branch_name)
+
+
 @contextmanager
 def cloned_repo(manager: "ManagerBase", branch: str = None, **clone_kwargs):
     """Clone the given Git repository and cd into it."""
@@ -102,17 +108,17 @@ def cloned_repo(manager: "ManagerBase", branch: str = None, **clone_kwargs):
                     == "true"
                 ):
                     repo.git.fetch(unshallow=True)
-                repo.git.checkout(branch)
+                fetch_and_checkout_branch(repo, branch)
             else:
                 repo = _clone_repo_and_set_vals(repo_url, ".", **clone_kwargs)
-                repo.git.checkout(branch)
+                fetch_and_checkout_branch(repo, branch)
             yield repo
             repo.git.stash()  # cleanup unused changes
             repo.git.clean("-xdf")
     else:
         with TemporaryDirectory() as repo_path, cwd(repo_path):
             repo = _clone_repo_and_set_vals(repo_url, repo_path, **clone_kwargs)
-            repo.git.checkout(branch)
+            fetch_and_checkout_branch(repo, branch)
             yield repo
             repo.git.stash()  # cleanup unused changes
             repo.git.clean("-xdf")


### PR DESCRIPTION
call repo.git.fetch("origin", branch_name) before doing any operations on
said branch. also contains a small change which ensures that the config init
pr is only opened once.

## Related Issues and Dependencies

fixes: https://github.com/thoth-station/support/issues/218
closes: https://github.com/thoth-station/kebechet/issues/1019

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
