### PR TITLE
A more informative version manager message around wrong versions

### DIFF
--- a/kebechet/managers/version/messages.py
+++ b/kebechet/managers/version/messages.py
@@ -56,3 +56,22 @@ files exist create one somewhere in your repository.
 
 **Related**: #{github_id}
 """
+
+UNABLE_TO_UPDATE_VERSION_ERROR = """
+Kebechet version manager had a problem when trying to update the version and can
+not continue with the process.
+
+Please see the details below for hints on where to find the cause of the
+problem. Once the root cause of the problem has been corrected you can request a
+new version update.
+
+Details:
+
+- File path: `{file_path}`
+- Line number: `{line_num}`
+- Old version: `{old_version}`
+- Issue: `{reason}`
+
+Environment details:
+{environment_details}
+"""


### PR DESCRIPTION
## Related Issues and Dependencies

Fixes #1079

## This introduces a breaking change

- No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Provide more details when there is a problem in updating the version.

In particular: when there is an exception related to SemVer being unable to parse the old/original version, expand the text in the related `VersionError` exception to help the user identify the cause of the problem.