### PR TITLE
Issue: Kebechet was picking approvers from it's own OWNERS file

### DIFF
--- a/kebechet/managers/thoth_advise/thoth_advise.py
+++ b/kebechet/managers/thoth_advise/thoth_advise.py
@@ -230,8 +230,7 @@ class ThothAdviseManager(ManagerBase):
 
     def _get_users_with_permission(self) -> typing.List[str]:
         try:
-            with open("OWNERS", "r") as owners_file:
-                owners = yaml.safe_load(owners_file)
+            owners = yaml.safe_load(self.project.get_file_content("OWNERS"))
             permitted_users = list(map(str, owners.get("approvers") or [])) + [APP_NAME]
         except FileNotFoundError:
             permitted_users = list(self.project.who_can_merge_pr()) + [APP_NAME]


### PR DESCRIPTION
Fix: To pick approvers from CLONED repo


## Related Issues and Dependencies
https://github.com/thoth-station/ps-nlp/issues/151

https://github.com/shreekarSS/ps-nlp/issues/5



## Description

Kebechet will pull the approvers list from the cloned repository rather than its own OWNERS file.