### PR TITLE
bugfix: make labels for update manager default to empty list

### DIFF
--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -782,7 +782,7 @@ class UpdateManager(ManagerBase):
 
         return result
 
-    def run(self, labels: list) -> Optional[dict]:
+    def run(self, labels: list = []) -> Optional[dict]:
         """Create a pull request for each and every direct dependency in the given org/repo (slug)."""
         if self.parsed_payload:
             if self.parsed_payload.get("event") not in _EVENTS_SUPPORTED:


### PR DESCRIPTION
## Related Issues and Dependencies

fixes: https://github.com/thoth-station/support/issues/240

## This introduces a breaking change

- [ ] Yes
- [x] No
