### PR TITLE
fix: change the import method of managerbase in release_version

### DIFF
--- a/kebechet/managers/version/release_triggers.py
+++ b/kebechet/managers/version/release_triggers.py
@@ -24,7 +24,7 @@ import json
 
 from ogr.abstract import Issue, PullRequest
 from kebechet.utils import get_issue_by_title
-from kebechet.managers import ManagerBase
+from kebechet.managers.manager import ManagerBase
 
 from . import constants
 from .exceptions import VersionError


### PR DESCRIPTION
change the import method of managerbase in release_version
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/kebechet/issues/1091

