### PR TITLE
Prevent the Kebechet advice manager from initiating multiple advice requests

### DIFF
--- a/kebechet/managers/thoth_advise/thoth_advise.py
+++ b/kebechet/managers/thoth_advise/thoth_advise.py
@@ -317,8 +317,6 @@ class ThothAdviseManager(ManagerBase):
                     runtime_environments = [
                         e["name"] for e in thoth_config["runtime_environments"]
                     ]
-                    for e in thoth_config["runtime_environments"]:
-                        runtime_environments.append(e["name"])
                 else:
                     runtime_environments = [
                         thoth_config["runtime_environments"][0]["name"]


### PR DESCRIPTION

Signed-off-by: Shreekara <sshreeka@redhat.com>

## Related Issues and Dependencies

Fixes: https://github.com/thoth-station/kebechet/issues/1069

## Description

Update run() method to prevent adding duplicate runtime_environments
from .thoth.yaml
