### PR TITLE
call sync when generating dependency graph

### DIFF
--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -118,7 +118,9 @@ pipenv version: {pipenv_version}
     def get_dependency_graph(cls, graceful: bool = False):
         """Get dependency graph of the project."""
         try:
-            cls.run_pipenv("pipenv install --dev --skip-lock")
+            cls.run_pipenv(
+                "pipenv sync --dev"
+            )  # use sync so that deps are from Pipfile.lock
             return cls.run_pipenv("pipenv graph")
         except PipenvError as exc:
             if not graceful:


### PR DESCRIPTION
otherwise arbitrary sub-dependencies will be found to satisfy the requirements

I noticed install was being called here which takes longer but also gets an arbitrary dependency graph. Sync will install deps directly from the lockfile