### PR TITLE
remove hidden files during os walk

### DIFF
--- a/kebechet/managers/version/release_triggers.py
+++ b/kebechet/managers/version/release_triggers.py
@@ -94,7 +94,12 @@ class BaseTrigger:
     ) -> List[Tuple[str, str, str]]:
         """Walk through the directory structure and try to adjust version identifier in sources."""
         adjusted = []
-        for root, _, files in os.walk("./"):
+        for root, dirs, files in os.walk("./"):
+            dirs[:] = [
+                d for d in dirs if not d[0] == "."
+            ]  # remove hidden dirs (done in place to remove from walk)
+            files = [f for f in files if not f[0] == "."]  # remove hidden files
+
             for file_name in files:
                 if file_name in (
                     "setup.py",


### PR DESCRIPTION
## Related Issues and Dependencies

fixes: https://github.com/thoth-station/kebechet/issues/1107

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

ignore hidden files and directories during walk

`.venv` dir can be created in cloned directory by update manager which messes with version discovery and writing