### PR TITLE
add check for no PRs opened

### DIFF
--- a/kebechet/managers/update/update.py
+++ b/kebechet/managers/update/update.py
@@ -828,12 +828,18 @@ class UpdateManager(ManagerBase):
                     issue.close()
 
             else:
-                self.close_issue_and_comment(
-                    _ISSUE_MANUAL_UPDATE,
-                    comment=CLOSE_MANUAL_ISSUE_COMMENT_PR.format(
-                        pr=self._pr_list[0],
-                        time=datetime.now().strftime("%m/%d/%Y, %H:%M:%S"),
-                    ),
-                )
+                if self._pr_list:
+                    self.close_issue_and_comment(
+                        _ISSUE_MANUAL_UPDATE,
+                        comment=CLOSE_MANUAL_ISSUE_COMMENT_PR.format(
+                            pr=self._pr_list[0],
+                            time=datetime.now().strftime("%m/%d/%Y, %H:%M:%S"),
+                        ),
+                    )
+                else:
+                    self.close_issue_and_comment(
+                        _ISSUE_MANUAL_UPDATE,
+                        comment="The dependencies are already up to date. No update is needed at this time.",
+                    )
 
         return results


### PR DESCRIPTION
## Related Issues and Dependencies

fixes: #1145 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

add check to see if any PRs were opened by the update manager.