### PR TITLE
Add 'allow' and 'disallow' setting to each manager

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -85,3 +85,62 @@ Kebechet works as a part of Thoth Ecosystem, please raise an issue or add the
 new manager to the `KebechetGithubAppInstallations
 <https://github.com/thoth-station/storages/blob/15ed39ef6c8d7bf58037046f3bab2465c5c4bb22/thoth/storages/graph/models.py#L1434>`_
 table.
+
+
+Configure different managers per Overlays
+-----------------------------------------
+
+- Add allow and disallow to each manager's configuration options, where the user can specify which manager is (dis)allowed for each overlay.
+
+Example: .thoth.yaml
+
+.. code-block:: yaml
+
+        host: khemenu.thoth-station.ninja
+        tls_verify: true
+        requirements_format: pipenv
+        overlays_dir: overlays
+
+        runtime_environments:
+          - name: ps-nlp
+            operating_system:
+              name: ubi
+            version: "8"
+            python_version: "3.8"
+            recommendation_type: latest
+
+          - name: ps-nlp-pytorch
+            operating_system:
+              name: ubi
+            version: "8"
+            python_version: "3.8"
+            recommendation_type: latest
+
+          - name: ps-nlp-tensorflow
+            operating_system:
+              name: ubi
+            version: "8"
+            python_version: "3.8"
+            recommendation_type: latest
+
+          - name: ps-nlp-tensorflow-gpu
+            operating_system:
+              name: ubi
+            version: "8"
+            python_version: "3.8"
+            recommendation_type: latest
+        managers:
+          - name: thoth-advise
+            # Do not run this manager in the ps-nlp-tensorflow-gpu overlay
+            env_disallow_list:
+              - ps-nlp-tensorflow-gpu
+            configuration:
+              labels: [bot]
+          - name: update
+            # Run this manager in the ps-nlp-tensorflow-gpu overlay (only)
+            env_allow_list:
+              - ps-nlp-tensorflow-gpu
+            configuration:
+              labels: [bot]
+          - name: info
+          # No allow/disallow present: this manager applies to all runtimes

--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -47,7 +47,7 @@ class ManagerBase:
         service_type: str,
         parsed_payload: Optional[dict] = None,
         metadata: Optional[dict] = None,
-        runtime_environment: Optional[str] = None,
+        runtime_environments: List[str] = None,
     ):
         """Initialize manager instance for talking to services."""
         self.service_url: str = service.instance_url  # type: ignore
@@ -66,7 +66,7 @@ class ManagerBase:
         self.project = service.get_project(namespace=self.owner, repo=self.repo_name)
         self._repo: git.Repo = None
         self.metadata = metadata
-        self.runtime_environment = runtime_environment
+        self.runtime_environments = runtime_environments
 
     @property
     def repo(self):

--- a/kebechet/managers/thoth_advise/thoth_advise.py
+++ b/kebechet/managers/thoth_advise/thoth_advise.py
@@ -294,7 +294,6 @@ class ThothAdviseManager(ManagerBase):
         self._issue_list = self.project.get_issue_list()
         self._close_advise_issues4users_lacking_perms()
         self._tracking_issue = self._close_all_but_oldest_issue()
-        runtime_environments: typing.List[typing.Tuple[str, Issue]]
 
         if analysis_id is None:
             if self._tracking_issue is None:
@@ -311,16 +310,7 @@ class ThothAdviseManager(ManagerBase):
 
                 with open(".thoth.yaml", "r") as f:
                     thoth_config = yaml.safe_load(f)
-
-                if thoth_config.get("overlays_dir"):
-                    runtime_environments = [
-                        e["name"] for e in thoth_config["runtime_environments"]
-                    ]
-                else:
-                    runtime_environments = [
-                        thoth_config["runtime_environments"][0]["name"]
-                    ]
-                for e in runtime_environments:
+                for e in self.runtime_environments or []:
                     try:
                         analysis_id = lib.advise_here(
                             nowait=True,


### PR DESCRIPTION
Signed-off-by: Shreekara <sshreeka@redhat.com>

## Related Issues and Dependencies
Fixes: https://github.com/thoth-station/kebechet/issues/1126
…

## This Pull Request implements
New config setting for managers in .thoth.yaml
For ex: 

managers:
  - name: thoth-advise
	//Do not run this manager in the ps-nlp-tensorflow-gpu overlay
	env_disallow_list:
	- ps-nlp-tensorflow-gpu
	configuration:
	  labels: [bot]
  - name: update
       //Run this manager in the ps-nlp-tensorflow-gpu overlay (only)
	env_allow_list:
	- ps-nlp-tensorflow-gpu
	configuration:
	  labels: [bot]
  - name: info
	//No allow/disallow present: this manager applies to all runtimes
...
