### PR TITLE
make PR description independent of issue description

### DIFF
--- a/kebechet/managers/version/release_triggers.py
+++ b/kebechet/managers/version/release_triggers.py
@@ -430,32 +430,24 @@ class ReleaseIssue(BaseTrigger):
                 f"The version found in sources is not a valid SemVer string: `{old_version}`"
             ) from e
 
-    def _adjust_pr_body(self) -> str:
-        if not self.issue.description:
-            return ""
+    def _get_pr_greeting(self) -> str:
+        greeting = f"Hey, @{self.issue.author}!\n\n"
 
-        result = "\n".join(self.issue.description.splitlines())
-        result = result.replace(
-            "Hey, Kebechet!\n\nCreate a new patch release, please.",
-            f"Hey, @{self.issue.author}!\n\nOpening this PR to fix the last release.",
-        )
-
-        result = result.replace(
-            "Hey, Kebechet!\n\nCreate a new minor release, please.",
-            f"Hey, @{self.issue.author}!\n\nOpening this PR to create a release in a backwards compatible manner.",
-        )
-
-        return result.replace(
-            "Hey, Kebechet!\n\nCreate a new major release, please.",
-            f"Hey, @{self.issue.author}!\n\nYour possible backwards incompatible changes will be released by this PR.",
-        )
+        if self.issue.title.lower == self._TITLE2UPDATE_INDEX[3]:  # patch
+            return f"{greeting}Opening this PR to fix the last release.\n"
+        elif self.issue.title.lower == self._TITLE2UPDATE_INDEX[2]:  # minor
+            return f"{greeting}Opening this PR to create a release in a backwards compatible manner.\n"
+        elif self.issue.title.lower == self._TITLE2UPDATE_INDEX[1]:  # major
+            return f"{greeting}Your possible backwards incompatible changes will be released by this PR.\n"
+        else:  # default
+            return f"{greeting}Creating requested release.\n"
 
     def construct_pr_body(self, changelog: List[str], has_prev_release: bool) -> str:
         """Construct body of the opened pull request with version update."""
         # Copy body from the original issue, this is helpful in case of
         # instrumenting CI (e.g. Depends-On in case of Zuul) so automatic
         # merges are perfomed as desired.
-        body = self._adjust_pr_body()
+        body = self._get_pr_greeting()
         truncated_changelog = changelog[: constants._MAX_CHANGELOG_SIZE]
         if not has_prev_release:
             body = body + "\n" + RELEASE_TAG_MISSING_WARNING


### PR DESCRIPTION
Issue description contains text which doesn't pertain to the PR, leaving it off should remove confusion without impacting overall readability; the triggering issue is already directly linked in the PR.

Signed-off-by: Kevin <kpostlet@redhat.com>

## Related Issues and Dependencies

fixes: #1153 

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

I removed the code which replaces the issue body and uses it as the base text for the PR description. Instead replacing it with just a string based on the release type requested.
