### PR TITLE
add default in case there are no runtime environments

### DIFF
--- a/kebechet/kebechet_runners.py
+++ b/kebechet/kebechet_runners.py
@@ -179,8 +179,11 @@ def run(
         runtime_environments = [
             e["name"] for e in config.config.get("runtime_environments")
         ]
-    else:
+    elif config.config.get("runtime_environments"):
         runtime_environments = [config.config["runtime_environments"][0]["name"]]
+    else:
+        runtime_environments = []
+
     for manager in managers:
         # We do pops on dict, which changes it. Let's create a soft duplicate so if a user uses
         # YAML references, we do not break.


### PR DESCRIPTION
some managers do not require python runtime environments, like the version manager. I changed to use an empty list as a default in this case. Any loops over runtime environments just won't run

Signed-off-by: Kevin <kpostlet@redhat.com>

## Related Issues and Dependencies

fixes: #1169 

