### PR TITLE
Use git add command instead of index.add from gitpython

### DIFF
--- a/kebechet/managers/manager.py
+++ b/kebechet/managers/manager.py
@@ -177,9 +177,9 @@ pipenv version: {pipenv_version}
         cur_branch = self.repo.active_branch
         self.repo.git.checkout("HEAD", b=branch_name)
         try:
-            self.repo.index.add(files)
+            self.repo.git.add(files)
             self.repo.git.commit(f"--message='{commit_msg}'", "--signoff")
-            self.repo.remote().push(branch_name, force=force_push)
+            self.repo.remote().push(branch_name, force=force_push).raise_if_error()
         finally:  # always revert to original
             self.repo.git.checkout(
                 cur_branch


### PR DESCRIPTION
Use git add command instead of index.add from gitpython
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

fixes: #1174 

## This Pull Request implements

We are using git command method for add instead of index.add
as suggested here: https://github.com/gitpython-developers/GitPython/issues/292

## Description

With the method `repo.index.add(files)`
somehow that particular bit was include `.` files as well
which was causing in commits.

```
stderr: 'remote: error: object <xxx>: hasDot: contains '.'        
remote: fatal: fsck error in packed object        
error: remote unpack failed: index-pack abnormal exit

```